### PR TITLE
feat: add Supabase deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 Solidity USC
+=================
+
+## Supabase Deployment
+
+This project now supports running against a [Supabase](https://supabase.com/)
+PostgreSQL instance. Configure the following environment variable before
+starting the server:
+
+```bash
+export SUPABASE_DB_URL="<your-supabase-postgres-connection-string>"
+```
+
+If `SUPABASE_DB_URL` is not provided the application falls back to the
+traditional `DATABASE_URL` variable which can also point to a Supabase
+database. Both paths expect an SSL-enabled connection.
+
+Use the standard npm scripts to run the app:
+
+```bash
+npm run dev     # Next.js development server
+npm start       # Production build
+```

--- a/config/database.js
+++ b/config/database.js
@@ -1,11 +1,20 @@
 const { Pool } = require('pg');
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+// Allow connecting to Supabase or any Postgres database via connection string.
+// Prefer `SUPABASE_DB_URL` when available and fall back to the generic
+// `DATABASE_URL` which can still point to a Supabase instance.
+const connectionString = process.env.SUPABASE_DB_URL || process.env.DATABASE_URL;
 
+if (!connectionString) {
+  throw new Error('Database connection string is not set.');
+}
 
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString,
   ssl: {
+    // Supabase requires SSL, but it uses self-signed certificates in some
+    // environments. Rejecting unauthorized certificates would prevent the
+    // connection, so disable that check here.
     rejectUnauthorized: false,
   },
 });

--- a/server/updateProblems.js
+++ b/server/updateProblems.js
@@ -2,8 +2,16 @@ const fs = require('fs');
 const path = require('path');
 const { Client } = require('pg'); // PostgreSQL client
 
+// Use Supabase connection string when available so the problem loader works in
+// Supabase-hosted environments. Falls back to DATABASE_URL for compatibility
+// with local setups.
+const connectionString = process.env.SUPABASE_DB_URL || process.env.DATABASE_URL;
+
 const dbClient = new Client({
-  connectionString: process.env.DATABASE_URL,
+  connectionString,
+  ssl: {
+    rejectUnauthorized: false,
+  },
 });
 dbClient.connect();
 


### PR DESCRIPTION
## Summary
- allow configuration with SUPABASE_DB_URL and SSL for Supabase in database helpers
- document Supabase usage and connection setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68981c67c12c83248a436eac73308f40